### PR TITLE
Improve warning if the template isn't found

### DIFF
--- a/lib/Email.js
+++ b/lib/Email.js
@@ -38,8 +38,8 @@ function Email (template, options) {
 	// init template
 	this.root = options.root || process.cwd();
 	this.template = this.resolve(template);
-	if (!this.template) {
-		throw new Error('Invalid template (' + template + ')');
+	if (!isFile(this.template)) {
+		throw new Error('Invalid template (' + template + '), could not find file "' + this.template + '"');
 	}
 
 	// init transport
@@ -85,7 +85,7 @@ Email.prototype.resolve = function (name) {
 	// join the directory, filename and extension to get the full path
 	var filepath = path.join(dir, file + this.ext);
 	// if the file exists, return the resolved path, otherwise undefined
-	return isFile(filepath) ? filepath : undefined;
+	return filepath;
 };
 
 /*


### PR DESCRIPTION
Previously we'd only log

> *"Invalid template (simple)"*

which isn't very helpful. Now we log

> *"Invalid templat (simple), could not find file
'/User/somename/someproject/templates/simple.jade'"*

which is a lot more descriptive and easier to debug.