### PR TITLE
Throw an error if Email.send is used in the old way

### DIFF
--- a/lib/Email.js
+++ b/lib/Email.js
@@ -95,6 +95,13 @@ Takes renderOptions (i.e. local variables for the template) and sendOptions
 (passed to the transport) - see Readme.md for explanation
 */
 Email.prototype.send = function (renderOptions, sendOptions, callback) {
+	if (!callback) {
+		if (typeof sendOptions === 'function') {
+			throw new Error('[Email.send] Please pass renderOptions, sendOptions and a callback. See the documentation for more information!');
+		} else {
+			throw new Error('[Email.send] Please provide a callback as the last argument!');
+		}
+	}
 	if (!this.transport) {
 		return callback(new Error('Transport must be set to use Email.send()'));
 	}


### PR DESCRIPTION
Previously Email.send would take two arguments. Now it takes three, and
all three are required.

Should this be merged, we'll throw a descriptive error should people
still be using the old syntax!