### PR TITLE
[RFC] Add Nodemailer Transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ coverage
 # node-waf configuration
 .lock-wscript
 
+# nodemailer test configuration
+test.config.js
+
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 

--- a/lib/transports/mailgun/getRecipientsAndVars.js
+++ b/lib/transports/mailgun/getRecipientsAndVars.js
@@ -1,6 +1,6 @@
 var assign = require('object-assign');
 
-var processAddress = require('./processAddress');
+var processAddress = require('../../util/processAddress');
 
 function getRecipientsAndVars (to, vars) {
 	if (!vars) vars = {};

--- a/lib/transports/mailgun/getSendOptions.js
+++ b/lib/transports/mailgun/getSendOptions.js
@@ -1,7 +1,7 @@
 var assign = require('object-assign');
 
 var getRecipientsAndVars = require('./getRecipientsAndVars');
-var processAddress = require('./processAddress');
+var processAddress = require('../../util/processAddress');
 
 var defaultOptions = {
 	'apiKey': process.env.MAILGUN_API_KEY,

--- a/lib/transports/nodemailer/getRecipients.js
+++ b/lib/transports/nodemailer/getRecipients.js
@@ -1,0 +1,13 @@
+var processAddress = require('../../util/processAddress');
+
+function getRecipients (to) {
+	var recipients = [];
+	(Array.isArray(to) ? to : [to]).forEach(function (i) {
+		var rcpt = processAddress(i);
+		if (!rcpt.address) return;
+		recipients.push(rcpt.address);
+	});
+	return recipients;
+};
+
+module.exports = getRecipients;

--- a/lib/transports/nodemailer/getSendOptions.js
+++ b/lib/transports/nodemailer/getSendOptions.js
@@ -3,19 +3,8 @@ var assign = require('object-assign');
 var processAddress = require('../../util/processAddress');
 var getRecipients = require('./getRecipients');
 
-var smtpConfig = {
-	host: process.env.SMTP_HOST,
-	port: process.env.SMTP_PORT,
-	secure: true, // use SSL
-	auth: {
-		user: process.env.SMTP_USER,
-		pass: process.env.SMTP_PASS,
-	},
-};
-
 var defaultOptions = {
 	inlineCSS: true,
-	nodemailerConfig: smtpConfig,
 };
 
 function getSendOptions (options) {
@@ -25,7 +14,7 @@ function getSendOptions (options) {
 	options.from = processAddress(options.from);
 	// process recipients
 	options.to = getRecipients(options.to);
-	// process attachments
+	// process attachments, TODO needs testing
 	if (options.attachments) {
 		options.attachments = options.attachments.map(function (attachment) {
 			return {

--- a/lib/transports/nodemailer/getSendOptions.js
+++ b/lib/transports/nodemailer/getSendOptions.js
@@ -1,0 +1,44 @@
+var assign = require('object-assign');
+
+var processAddress = require('../../util/processAddress');
+var getRecipients = require('./getRecipients');
+
+var smtpConfig = {
+	host: process.env.SMTP_HOST,
+	port: process.env.SMTP_PORT,
+	secure: true, // use SSL
+	auth: {
+		user: process.env.SMTP_USER,
+		pass: process.env.SMTP_PASS,
+	},
+};
+
+var defaultOptions = {
+	inlineCSS: true,
+	nodemailerConfig: smtpConfig,
+};
+
+function getSendOptions (options) {
+	// default options
+	options = assign({}, defaultOptions, options);
+	// process from name and email
+	options.from = processAddress(options.from);
+	// process recipients
+	options.to = getRecipients(options.to);
+	// process attachments
+	if (options.attachments) {
+		options.attachments = options.attachments.map(function (attachment) {
+			return {
+				cid: attachment.cid,
+				filename: attachment.name,
+				content: attachment.content,
+				contentType: attachment.type,
+				encoding: 'base64',
+			};
+		});
+	}
+	// return
+	return options;
+}
+
+module.exports = getSendOptions;

--- a/lib/transports/nodemailer/index.js
+++ b/lib/transports/nodemailer/index.js
@@ -7,6 +7,9 @@ function send (email, options, callback) {
 	// init options
 	options = assign(getSendOptions(options), email);
 	// validate
+	if (!options.nodemailerConfig) {
+		return callback(new Error('No Nodemailer config'));
+	}
 	if (!options.to.length) {
 		return callback(new Error('No recipients to send to'));
 	}

--- a/lib/transports/nodemailer/index.js
+++ b/lib/transports/nodemailer/index.js
@@ -1,0 +1,25 @@
+var assign = require('object-assign');
+var nodemailer = require('nodemailer');
+var juice = require('juice');
+var getSendOptions = require('./getSendOptions');
+
+function send (email, options, callback) {
+	// init options
+	options = assign(getSendOptions(options), email);
+	// validate
+	if (!options.to.length) {
+		return callback(new Error('No recipients to send to'));
+	}
+	// inline css
+	if (options.inlineCSS) {
+		options.html = juice(options.html);
+	}
+	delete options.inlineCSS;
+	// init transporter
+	var transporter = nodemailer.createTransport(options.nodemailerConfig);
+	delete options.nodemailerConfig;
+	// send emails
+	transporter.sendMail(options, callback);
+}
+
+module.exports = send;

--- a/lib/util/processAddress.js
+++ b/lib/util/processAddress.js
@@ -1,4 +1,4 @@
-var truthy = require('../../util/truthy');
+var truthy = require('./truthy');
 
 var ADDRESS_RX = /.*<(.*)>/;
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lodash": "^4.15.0",
     "mailgun-js": "^0.7.12",
     "mandrill-api": "^1.0.45",
+    "nodemailer": "^2.6.0",
     "object-assign": "^4.1.0"
   },
   "devDependencies": {

--- a/test-send.js
+++ b/test-send.js
@@ -3,6 +3,19 @@ This file sends an email with a test template to an email address.
 
 Usage:
 	TO=user@keystonejs.com MAILGUN_API_KEY=xyz MAILGUN_DOMAIN=abc TEMPLATE=simple node test-send
+
+For usage with Nodemailer you must first provide a test.config.js.
+Different transports can be specified and configured there, e.g SMTP:
+	module.exports = {
+		host: 'xyz',
+		port: 'abc',
+		auth: {
+			user: 'xyz',
+			pass: 'abc',
+		},
+	};
+then run
+	TO=user@keystonejs.com node test-send
 */
 
 var Email = require('./index');
@@ -14,8 +27,15 @@ var mailgunApiKey = process.env.MAILGUN_API_KEY;
 var mailgunDomain = process.env.MAILGUN_DOMAIN;
 var mandrillApiKey = process.env.MANDRILL_API_KEY;
 
-if (!mandrillApiKey && (!mailgunApiKey || !mailgunDomain)) {
-	throw Error('You must provide either or both Mailgun or Mandrill auth');
+var nodemailerConfig = require('./test.config.js');
+
+if (!mandrillApiKey && (!mailgunApiKey || !mailgunDomain) && !nodemailerConfig) {
+	throw Error('You must provide at least one auth config');
+}
+
+// default to simple template
+if (!template) {
+	template = 'simple';
 }
 
 var templateOptions = require('./tests/emails/' + template + '/options');
@@ -79,6 +99,34 @@ if (mandrillApiKey) {
 				console.error('🤕 Mandrill test failed with error:\n', err);
 			} else {
 				console.log('📬 Successfully sent Mandrill test with result:\n', result);
+			}
+		}
+	);
+}
+
+if (nodemailerConfig) {
+	Email.send(
+		// template path
+		templatePath,
+		// Email options
+		{
+			transport: 'nodemailer',
+		},
+		// Template locals
+		templateOptions,
+		// Send options
+		{
+			to: toArray,
+			subject: 'Why hello there! ... from keystone-email ' + Date.now(),
+			from: { name: 'Test', email: 'user@keystonejs.com' },
+			nodemailerConfig: nodemailerConfig,
+		},
+		// callback
+		function (err, result) {
+			if (err) {
+				console.error('🤕 Nodemailer test failed with error:\n', err);
+			} else {
+				console.log('📬 Successfully sent Nodemailer test with result:\n', result);
 			}
 		}
 	);

--- a/tests/index.js
+++ b/tests/index.js
@@ -63,36 +63,35 @@ describe('utils', function () {
 	});
 });
 
-describe('mailgun transport', function () {
+describe('processAddress', function () {
+	var processAddress = require('../lib/util/processAddress');
 
-	describe('processAddress', function () {
-		var processAddress = require('../lib/transports/mailgun/processAddress');
-
-		it('should set a string provided to both the address and the email', function () {
-			var res = processAddress(testEmail);
-			assert.equal(res.email, testEmail);
-			assert.equal(res.address, testEmail);
-		});
-
-		it('should process an object with a name and an email', function () {
-			var singlesObj = { email: testEmail, name: testName };
-			var res = processAddress(singlesObj);
-			assert.equal(res.email, testEmail);
-			assert.equal(res.address, testAddress);
-		});
-		it('should process an object that includes a name object', function () {
-			var multiObj = { email: testEmail, name: nameObj };
-			var res = processAddress(multiObj);
-			assert.equal(res.email, testEmail);
-			assert.equal(res.address, testAddress);
-			assert.equal(res.firstName, nameObj.first);
-			assert.equal(res.lastName, nameObj.last);
-		});
-		it('should do something if given an empty object');
-		// TODO: Behaviours if the object is the wrong shape? Does not include email,
-		// name only has name.first etc etc
+	it('should set a string provided to both the address and the email', function () {
+		var res = processAddress(testEmail);
+		assert.equal(res.email, testEmail);
+		assert.equal(res.address, testEmail);
 	});
 
+	it('should process an object with a name and an email', function () {
+		var singlesObj = { email: testEmail, name: testName };
+		var res = processAddress(singlesObj);
+		assert.equal(res.email, testEmail);
+		assert.equal(res.address, testAddress);
+	});
+	it('should process an object that includes a name object', function () {
+		var multiObj = { email: testEmail, name: nameObj };
+		var res = processAddress(multiObj);
+		assert.equal(res.email, testEmail);
+		assert.equal(res.address, testAddress);
+		assert.equal(res.firstName, nameObj.first);
+		assert.equal(res.lastName, nameObj.last);
+	});
+	it('should do something if given an empty object');
+	// TODO: Behaviours if the object is the wrong shape? Does not include email,
+	// name only has name.first etc etc
+});
+
+describe('mailgun transport', function () {
 	describe('get recipients and vars', function () {
 		var getRecipientsAndVars = require('../lib/transports/mailgun/getRecipientsAndVars');
 		it('return an object with recipients and vars', function () {
@@ -136,11 +135,22 @@ describe('mandrill transport', function () {
 		it('should add a new entry to vars with the name if there is a name string');
 		it('should split up a name object, and push name, first_name and last_name to vars');
 	});
+
 	describe('index function', function () {
 		it('');
 	});
 });
 
+describe('nodemailer transport', function () {
+	describe('get recipients', function () {
+		// var getRecipients = require('../lib/transports/nodemailer/getRecipients');
+		it('');
+	});
+
+	describe('index function', function () {
+		it('');
+	});
+});
 
 // describe('render method');
 // describe('getSendOptions for mailgun');

--- a/tests/index.js
+++ b/tests/index.js
@@ -55,40 +55,42 @@ describe('utils', function () {
 			assert.equal(typeof res2, 'function');
 		});
 	});
+
 	describe('is file', function () {
 		it('');
 	});
+
 	describe('is truthy', function () {
 		it('');
 	});
-});
 
-describe('processAddress', function () {
-	var processAddress = require('../lib/util/processAddress');
+	describe('processAddress', function () {
+		var processAddress = require('../lib/util/processAddress');
 
-	it('should set a string provided to both the address and the email', function () {
-		var res = processAddress(testEmail);
-		assert.equal(res.email, testEmail);
-		assert.equal(res.address, testEmail);
-	});
+		it('should set a string provided to both the address and the email', function () {
+			var res = processAddress(testEmail);
+			assert.equal(res.email, testEmail);
+			assert.equal(res.address, testEmail);
+		});
 
-	it('should process an object with a name and an email', function () {
-		var singlesObj = { email: testEmail, name: testName };
-		var res = processAddress(singlesObj);
-		assert.equal(res.email, testEmail);
-		assert.equal(res.address, testAddress);
+		it('should process an object with a name and an email', function () {
+			var singlesObj = { email: testEmail, name: testName };
+			var res = processAddress(singlesObj);
+			assert.equal(res.email, testEmail);
+			assert.equal(res.address, testAddress);
+		});
+		it('should process an object that includes a name object', function () {
+			var multiObj = { email: testEmail, name: nameObj };
+			var res = processAddress(multiObj);
+			assert.equal(res.email, testEmail);
+			assert.equal(res.address, testAddress);
+			assert.equal(res.firstName, nameObj.first);
+			assert.equal(res.lastName, nameObj.last);
+		});
+		it('should do something if given an empty object');
+		// TODO: Behaviours if the object is the wrong shape? Does not include email,
+		// name only has name.first etc etc
 	});
-	it('should process an object that includes a name object', function () {
-		var multiObj = { email: testEmail, name: nameObj };
-		var res = processAddress(multiObj);
-		assert.equal(res.email, testEmail);
-		assert.equal(res.address, testAddress);
-		assert.equal(res.firstName, nameObj.first);
-		assert.equal(res.lastName, nameObj.last);
-	});
-	it('should do something if given an empty object');
-	// TODO: Behaviours if the object is the wrong shape? Does not include email,
-	// name only has name.first etc etc
 });
 
 describe('mailgun transport', function () {


### PR DESCRIPTION
Adds Nodemailer to Transports.

As mentioned in #4 different transport configs like the ones from [nodemailer-wellknown](https://github.com/nodemailer/nodemailer-wellknown) add support for lots of providers including mandrill and mailgun out of the box. 
I reckon a tighter integration with Nodemailer could allow for supporting more services more effortlessly and eventually streamline this lib here quite a bit.

Shoutout to @bgag I borrowed some bits and pieces from keystone-nodemailer, thanks :)

Everyone, please review and share your thoughts!

Edit: 
To test nodemailer you can now provide a config for any given transport in test.config.js and start send-test.js