### PR TITLE
Always ensure . at beginning of ext

### DIFF
--- a/lib/Email.js
+++ b/lib/Email.js
@@ -38,6 +38,10 @@ function Email (template, options) {
 	if (typeof this.engine !== 'function') {
 		throw new Error('Invalid engine (' + engine + ')');
 	}
+	// this corrects for if options.ext is passed in without the `.`
+	if (this.ext[0] !== '.') {
+		this.ext = '.' + this.ext;
+	}
 
 	// init template
 	this.root = options.root || process.cwd();


### PR DESCRIPTION
This was mostly an issue when providing a viewEngine through keystone, as keystone would provide the viewEngine unmodified, and the convention was to provide the view engine without the `.`