### PR TITLE
Fixed import path for NodeMailer transport

### DIFF
--- a/lib/transports/nodemailer/index.js
+++ b/lib/transports/nodemailer/index.js
@@ -1,4 +1,4 @@
-var requireOptional = require('../util/requireOptional');
+var requireOptional = require('../../util/requireOptional');
 
 var assign = require('object-assign');
 var nodemailer = requireOptional('nodemailer', 'Please install the nodemailer package to use this transport');


### PR DESCRIPTION
The relative import path for `requireOptional` was incorrect and needed an additional `../` prefixed to the existing path to allow the utility module to be located/imported